### PR TITLE
Add browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@
 This hack generates a copy of the [astro-ph](https://arxiv.org/list/astro-ph/new) listings on [arXiv.org](https://arxiv.org) where the abstracts are randomly reordered instead of chronological order. This copy is then hosted at [arXiv.ninja](https://arxiv.ninja) via a series of tubes (e.g. [Travis](https://travis-ci.org/dfm/arxiv.ninja)).
 
 Made by [Dan F-M](https://github.com/dfm) and [Adrian P-W](https://github.com/adrn)
+
+
+## Browser extension
+
+Alternatively, the `extension` directory has code for a
+[Firefox add-on](https://addons.mozilla.org/en-GB/firefox/addon/arxiv-ninja/)
+and
+[Chrome extension](https://chrome.google.com/webstore/detail/arxivninja/dmjcjhaabdbegbodbbpohbjagkchoonb).
+These randomize the new and recent listings within your browser for [arXiv.org](https://arxiv.org) itself.
+
+Alternatively, you can open `extension/arxiv_ninja.user.js` with "user script" extensions like
+[Greasemonkey](https://addons.mozilla.org/en-GB/firefox/addon/greasemonkey/),
+and [Tampermonkey](https://tampermonkey.net/).
+
+Browser extension by [Iain M](https://github.com/imurray/)

--- a/extension/arxiv_ninja.user.js
+++ b/extension/arxiv_ninja.user.js
@@ -1,8 +1,10 @@
 // ==UserScript==
 // @name         arxiv.ninja
 // @description  reorder papers on arXiv new pages
-// @version      0.1.1
+// @version      0.1.2
 // @include      https://arxiv.org/list/*/new*
+// @include      https://arxiv.org/list/*/recent*
+// @include      https://arxiv.org/list/*/pastweek*
 // @grant        none
 // ==/UserScript==
 

--- a/extension/arxiv_ninja.user.js
+++ b/extension/arxiv_ninja.user.js
@@ -1,0 +1,38 @@
+// ==UserScript==
+// @name         arxiv.ninja
+// @description  reorder papers on arXiv new pages
+// @version      0.1.1
+// @include      https://arxiv.org/list/*/new*
+// @grant        none
+// ==/UserScript==
+
+// Iain Murray, August 2018
+
+(function(){
+    var links = document.getElementsByTagName('a');
+    var blocks = document.getElementsByTagName('dl');
+    var i = blocks.length;
+    while (i--) {
+        // Extract parts of this block
+        var titles = blocks[i].getElementsByTagName('dt');
+        var bits = blocks[i].getElementsByTagName('dd');
+        var old_first_name = titles[0].childNodes[0].getAttribute('name');
+    
+        // Randomly shuffle the papers within this block
+        var N = titles.length;
+        for (var j=0; j<N; j++) {
+            var idx = j + Math.floor(Math.random() * (N - j));
+            blocks[i].insertBefore(bits[idx], titles[0]);
+            blocks[i].insertBefore(titles[idx], bits[0]);
+        }
+    
+        // Re-write within-page links to still point to the top of the block
+        var new_first_name = titles[0].childNodes[0].getAttribute('name');
+        var nl = links.length;
+        while (nl--) {
+            if (links[nl].getAttribute('href') == '#' + old_first_name) {
+                links[nl].setAttribute('href', '#' + new_first_name);
+            }
+        }
+    }
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
 
   "manifest_version": 2,
   "name": "arxiv.ninja",
-  "version": "0.1.1",
+  "version": "0.1.2",
 
   "description": "arxiv.ninja swoops in and randomly re-orders the papers on the arXiv new pages.",
 
@@ -11,7 +11,9 @@
   "content_scripts": [
     {
       "matches": [
-        "*://arxiv.org/list/*/new*"
+        "*://arxiv.org/list/*/new*",
+        "*://arxiv.org/list/*/recent*",
+        "*://arxiv.org/list/*/pastweek*"
       ],
       "js": ["arxiv_ninja.user.js"]
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,20 @@
+{
+
+  "manifest_version": 2,
+  "name": "arxiv.ninja",
+  "version": "0.1.1",
+
+  "description": "arxiv.ninja swoops in and randomly re-orders the papers on the arXiv new pages.",
+
+  "homepage_url": "https://github.com/dfm/arxiv.ninja",
+
+  "content_scripts": [
+    {
+      "matches": [
+        "*://arxiv.org/list/*/new*"
+      ],
+      "js": ["arxiv_ninja.user.js"]
+    }
+  ]
+
+}

--- a/zip_extension.sh
+++ b/zip_extension.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+EXTENSION=arxiv.ninja
+SRC=extension
+
+# Set working directory to location of this script
+cd $(dirname $(readlink -m "$0"))
+
+VERSION=$(grep '"version":' "$SRC"/manifest.json | sed 's/.*"\([0-9.]*\)".*/\1/')
+OUT="$EXTENSION"-"$VERSION"
+
+# Create a zip file that can be uploaded to Firefox Addons or the Chrome Web Store
+rm -f "$OUT"
+cd "$SRC"
+zip -r -FS ../"$OUT".zip *
+echo Created .zip web extension: "$OUT".zip
+


### PR DESCRIPTION
I've added an extension directory with javascript for in-browser re-ordering of arXiv listings.

I've also added a shell script to create a .zip file of the extension, for upload to the Mozilla and Google stores. I've uploaded the resulting .zip to these stores, and added links to the README.md.